### PR TITLE
Remove react duplication in JLab 0.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "react": "~16.2.0",
-    "react-dom": "~16.2.0"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "~16.4.2",
+    "react-dom": "~16.4.2"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,15 +1547,6 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
-react-dom@~16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-dom@~16.4.0:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
@@ -1565,9 +1556,9 @@ react-dom@~16.4.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@~16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react-dom@~16.4.2:
+  version "16.4.2"
+  resolved "http://localhost:8080/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -1577,6 +1568,15 @@ react@~16.2.0:
 react@~16.4.0:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@~16.4.2:
+  version "16.4.2"
+  resolved "http://localhost:8080/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
There are version clashes when installing the extension with JLab 0.34 for react and react-dom:
```
WARNING in react
  Multiple versions of react found:
    16.2.0 ./~/@jupyterlab\toc/~/react from ./~/@jupyterlab\toc/~/react\index.js

    16.4.2 ./~/react from ./~/react\index.js


WARNING in react-dom
  Multiple versions of react-dom found:
    16.2.1 ./~/@jupyterlab\toc/~/react-dom from ./~/@jupyterlab\toc/~/react-dom\
index.js
    16.4.2 ./~/react-dom from ./~/react-dom\index.js
```

Nota: I have not tested it. Hence the WIP.