### PR TITLE
Again, don't parse for headers in code block.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ian-r-rose/jupyterlab-toc.git"
+    "url": "https://github.com/jupyterlab/jupyterlab-toc.git"
   },
   "scripts": {
     "build": "tsc",

--- a/src/generators/markdowndocgenerator/index.ts
+++ b/src/generators/markdowndocgenerator/index.ts
@@ -129,9 +129,18 @@ namespace Private {
     const lines = text.split('\n');
     let headings: INumberedHeading[] = [];
 
+    let inCodeBlock = false;
     // Iterate over the lines to get the header level and
     // the text for the line.
     lines.forEach((line, idx) => {
+      // Don't check for markdown headings if we
+      // are in a code block (demarcated by backticks).
+      if (line.indexOf('```') === 0) {
+        inCodeBlock = !inCodeBlock;
+      }
+      if (inCodeBlock) {
+        return;
+      }
       // Make an onClick handler for this line.
       const onClick = onClickFactory(idx);
 

--- a/src/generators/notebookgenerator/index.ts
+++ b/src/generators/notebookgenerator/index.ts
@@ -522,8 +522,7 @@ namespace Private {
     // Split the text into lines.
     const lines = text.split('\n');
 
-    // Iterate over the lines to get the header level and
-    // the text for the line.
+    // Get the first line an check if it is a header.
     const line = lines[0];
     const line2 = lines.length > 1 ? lines[1] : undefined;
     // Make an onClick handler for this line.


### PR DESCRIPTION
Fixes #52.