### PR TITLE
Add ability to enable / disable collapsible notebook cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Project Jupyter",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",
@@ -74,6 +75,7 @@
     "access": "public"
   },
   "jupyterlab": {
-    "extension": "lib/extension.js"
+    "extension": "lib/extension.js",
+    "schemaDir": "schema"
   }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,0 +1,25 @@
+{
+  "title": "Table of Contents",
+  "description": "Table of contents settings.",
+  "definitions": {
+    "tocConfig": {
+      "properties": {
+        "collapsibleNotebooks": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "properties": {
+    "tocConfig": {
+      "title": "ToC Configuration",
+      "description": "The configuration for the table of contents.",
+      "$ref": "#/definitions/tocConfig",
+      "default": {
+        "collapsibleNotebooks": true
+      }
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -3,13 +3,9 @@
   "description": "Table of contents settings.",
   "properties": {
     "collapsibleNotebooks": {
-      "type": "boolean"
-    }
-  },
-  "properties": {
-    "collapsibleNotebooks": {
       "title": "ToC Configuration",
       "description": "Specifies whether to allow the ToC extension to collapse notebook cells.",
+      "type": "boolean",
       "default": true
     }
   },

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,18 +1,15 @@
 {
   "title": "Table of Contents",
   "description": "Table of contents settings.",
-  "definitions": {
-    "properties": {
-      "collapsibleNotebooks": {
-        "type": "boolean"
-      }
+  "properties": {
+    "collapsibleNotebooks": {
+      "type": "boolean"
     }
   },
   "properties": {
     "collapsibleNotebooks": {
       "title": "ToC Configuration",
       "description": "Specifies whether to allow the ToC extension to collapse notebook cells.",
-      "$ref": "#/definitions",
       "default": true
     }
   },

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -6,7 +6,7 @@
       "title": "ToC Configuration",
       "description": "Specifies whether to allow the ToC extension to collapse notebook cells.",
       "type": "boolean",
-      "default": true
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,22 +2,18 @@
   "title": "Table of Contents",
   "description": "Table of contents settings.",
   "definitions": {
-    "tocConfig": {
-      "properties": {
-        "collapsibleNotebooks": {
-          "type": "boolean"
-        }
+    "properties": {
+      "collapsibleNotebooks": {
+        "type": "boolean"
       }
     }
   },
   "properties": {
-    "tocConfig": {
+    "collapsibleNotebooks": {
       "title": "ToC Configuration",
-      "description": "The configuration for the table of contents.",
-      "$ref": "#/definitions/tocConfig",
-      "default": {
-        "collapsibleNotebooks": true
-      }
+      "description": "A setting for specifying whether to allow collapsing notebook cells.",
+      "$ref": "#/definitions",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -11,7 +11,7 @@
   "properties": {
     "collapsibleNotebooks": {
       "title": "ToC Configuration",
-      "description": "A setting for specifying whether to allow collapsing notebook cells.",
+      "description": "Specifies whether to allow the ToC extension to collapse notebook cells.",
       "$ref": "#/definitions",
       "default": true
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ async function activateTOC(
   labShell.add(toc, 'left', { rank: 700 });
 
   // Add the ToC widget to the application restorer:
-  restorer.add(toc, 'juputerlab-toc');
+  restorer.add(toc, '@jupyterlab/toc:plugin');
 
   // Attempt to load plugin settings:
   let settings: ISettingRegistry.ISettings | undefined;
@@ -144,7 +144,7 @@ async function activateTOC(
  * @private
  */
 const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
-  id: 'toc',
+  id: '@jupyterlab/toc:plugin',
   autoStart: true,
   provides: ITableOfContentsRegistry,
   requires: [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,7 +144,7 @@ async function activateTOC(
  * @private
  */
 const extension: JupyterFrontEndPlugin<ITableOfContentsRegistry> = {
-  id: 'jupyterlab-toc',
+  id: 'toc',
   autoStart: true,
   provides: ITableOfContentsRegistry,
   requires: [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ function activateTOC(
   // Add the ToC widget to the application restorer:
   restorer.add(toc, 'juputerlab-toc');
 
-  // Load the configuration of whether to enable collapsing behavior
+  // Attempt to load plugin settings:
   settingRegistry.load('@jupyterlab/toc:plugin').then(settings => {
     const config = settings.get('tocConfig').composite as JSONObject;
     const collapsibleNotebooks = config.collapsibleNotebooks as boolean;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,6 @@ import { IMarkdownViewerTracker } from '@jupyterlab/markdownviewer';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-
 import { TableOfContents } from './toc';
 import {
   createLatexGenerator,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,7 @@ async function activateTOC(
     settings = await settingRegistry.load('@jupyterlab/toc:plugin');
   } catch (error) {
     console.error(
-      'Failed to load settings for the Table of Contents extension.'
+      `Failed to load settings for the Table of Contents extension.\n\n${error}`
     );
   }
 

--- a/src/generators/notebook/index.ts
+++ b/src/generators/notebook/index.ts
@@ -31,10 +31,12 @@ import { toolbar } from './toolbar_generator';
 function createNotebookGenerator(
   tracker: INotebookTracker,
   widget: TableOfContents,
+  collapsibleNotebooks: boolean,
   sanitizer: ISanitizer
 ): Registry.IGenerator<NotebookPanel> {
   const options = new OptionsManager(widget, tracker, {
     numbering: false,
+    collapsibleNotebooks: collapsibleNotebooks,
     sanitizer: sanitizer
   });
   return {

--- a/src/generators/notebook/index.ts
+++ b/src/generators/notebook/index.ts
@@ -4,6 +4,7 @@
 import { ISanitizer } from '@jupyterlab/apputils';
 import { CodeCell, CodeCellModel, MarkdownCell, Cell } from '@jupyterlab/cells';
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { TableOfContentsRegistry as Registry } from '../../registry';
 import { TableOfContents } from '../../toc';
 import { isMarkdown } from '../../utils/is_markdown';
@@ -31,9 +32,13 @@ import { toolbar } from './toolbar_generator';
 function createNotebookGenerator(
   tracker: INotebookTracker,
   widget: TableOfContents,
-  collapsibleNotebooks: boolean,
-  sanitizer: ISanitizer
+  sanitizer: ISanitizer,
+  settings?: ISettingRegistry.ISettings
 ): Registry.IGenerator<NotebookPanel> {
+  let collapsibleNotebooks = true;
+  if (settings) {
+    collapsibleNotebooks = settings.composite.collapsibleNotebooks as boolean;
+  }
   const options = new OptionsManager(widget, tracker, {
     numbering: false,
     collapsibleNotebooks: collapsibleNotebooks,

--- a/src/generators/notebook/options_manager.ts
+++ b/src/generators/notebook/options_manager.ts
@@ -22,7 +22,7 @@ interface Options {
   sanitizer: ISanitizer;
 
   /**
-   * Boolean indicating whether notebook cells collapsible
+   * Boolean indicating whether notebook cells are collapsible.
    */
   collapsibleNotebooks: boolean;
 

--- a/src/generators/notebook/options_manager.ts
+++ b/src/generators/notebook/options_manager.ts
@@ -22,6 +22,11 @@ interface Options {
   sanitizer: ISanitizer;
 
   /**
+   * Boolean indicating whether notebook cells collapsible
+   */
+  collapsibleNotebooks: boolean;
+
+  /**
    * Tag tool component.
    */
   tagTool?: TagsToolComponent;
@@ -50,6 +55,7 @@ class OptionsManager extends Registry.IOptionsManager {
     this._numbering = options.numbering;
     this._widget = widget;
     this._notebook = notebook;
+    this._collapsible = options.collapsibleNotebooks;
     this.sanitizer = options.sanitizer;
     this.storeTags = [];
   }
@@ -90,6 +96,13 @@ class OptionsManager extends Registry.IOptionsManager {
 
   get numbering() {
     return this._numbering;
+  }
+
+  /**
+   * Gets ToC configuration of whether to enable collapsible cells
+   */
+  get collapsibleNotebooks() {
+    return this._collapsible;
   }
 
   /**
@@ -195,6 +208,7 @@ class OptionsManager extends Registry.IOptionsManager {
   private _showMarkdown = false;
   private _showTags = false;
   private _notebook: INotebookTracker;
+  private _collapsible = false;
   private _widget: TableOfContents;
   private _tagTool: TagsToolComponent | null = null;
   public storeTags: string[];

--- a/src/generators/notebook/options_manager.ts
+++ b/src/generators/notebook/options_manager.ts
@@ -99,7 +99,7 @@ class OptionsManager extends Registry.IOptionsManager {
   }
 
   /**
-   * Gets ToC configuration of whether to enable collapsible cells
+   * Gets the ToC setting specifying whether to allow collapsing notebook cells.
    */
   get collapsibleNotebooks() {
     return this._collapsible;

--- a/src/generators/notebook/render.tsx
+++ b/src/generators/notebook/render.tsx
@@ -49,19 +49,24 @@ function render(
           'toc-hr-collapsed'
         ) as boolean;
 
-        // Render the twist button:
-        let button = twistButton(item.cellRef, collapsed || false, onClick);
-
         // Update the collapsed state of the corresponding notebook cell:
         setCollapsedState(tracker, item.cellRef, collapsed);
 
-        // Render the heading item:
-        jsx = (
-          <div className="toc-entry-holder">
-            {button}
-            {jsx}
-          </div>
-        );
+        // Only render the twist button if configured to enable collapsing behavior:
+        if (options.collapsibleNotebooks) {
+          let button = twistButton(item.cellRef, collapsed || false, onClick);
+
+          // Render the heading item:
+          jsx = (
+            <div className="toc-entry-holder">
+              {button}
+              {jsx}
+            </div>
+          );
+        } else {
+          // Render the heading item without the dropdown button:
+          jsx = <div className="toc-entry-holder">{jsx}</div>;
+        }
       }
       return jsx;
     }
@@ -76,14 +81,20 @@ function render(
         let collapsed = item.cellRef!.model.metadata.get(
           'toc-hr-collapsed'
         ) as boolean;
-        let button = twistButton(item.cellRef, collapsed || false, onClick);
-        setCollapsedState(tracker, item.cellRef, collapsed);
-        jsx = (
-          <div className="toc-entry-holder">
-            {button}
-            {jsx}
-          </div>
-        );
+
+        if (options.collapsibleNotebooks) {
+          let button = twistButton(item.cellRef, collapsed || false, onClick);
+          setCollapsedState(tracker, item.cellRef, collapsed);
+          jsx = (
+            <div className="toc-entry-holder">
+              {button}
+              {jsx}
+            </div>
+          );
+        } else {
+          // Render the heading item without the dropdown button:
+          jsx = <div className="toc-entry-holder">{jsx}</div>;
+        }
       }
       return jsx;
     }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -18,7 +18,7 @@ export interface ITableOfContentsRegistry extends TableOfContentsRegistry {}
  * Table of contents registry token.
  */
 export const ITableOfContentsRegistry = new Token<TableOfContentsRegistry>(
-  'toc:ITableOfContentsRegistry'
+  '@jupyterlab/toc:ITableOfContentsRegistry'
 );
 /* tslint:enable */
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -18,7 +18,7 @@ export interface ITableOfContentsRegistry extends TableOfContentsRegistry {}
  * Table of contents registry token.
  */
 export const ITableOfContentsRegistry = new Token<TableOfContentsRegistry>(
-  'jupyterlab-toc:ITableOfContentsRegistry'
+  'toc:ITableOfContentsRegistry'
 );
 /* tslint:enable */
 


### PR DESCRIPTION
Patch for #123 to allow users to disable the collapsing cells feature of ToC.
Adds a setting in the Jupyter lab setting registry to enable/disable the collapsing feature of ToC in notebooks. Removes the dropdown feature in Toc but leaves the blue side bar, so some collapse behavior is still present. I left the blue side bar to collapse individual cells because I wasn't sure if this part of the collapsing feature was bothering people - I can remove that as well if so. 

To try out changing this configuration, open the settings menu of Jupyter lab (shortcut is ⌘ , ) and add the configuration under "User Preferences" like this: 
![image](https://user-images.githubusercontent.com/6673460/81228948-a39bbf80-8fb4-11ea-9eeb-de79f4b3544f.png)
Then, reload the page in your browser and the changes should be visible. 

When collapsibleNotebooks is set to false, the extension looks like this:
![image](https://user-images.githubusercontent.com/6673460/81228727-31c37600-8fb4-11ea-9f66-fed1f8da756f.png)
After clicking the blue side bar:
![image](https://user-images.githubusercontent.com/6673460/81228747-3d16a180-8fb4-11ea-9f5c-a5e317c8950a.png)

Fixes #123