### PR TITLE
[feature request]: make toc iterable with arrow buttons 

### DIFF
--- a/src/toc_item.tsx
+++ b/src/toc_item.tsx
@@ -48,6 +48,13 @@ class TOCItem extends React.Component<IProperties, IState> {
     // Create an onClick handler for the TOC item
     // that scrolls the anchor into view.
     const onClick = (event: React.SyntheticEvent<HTMLSpanElement>) => {
+      event.currentTarget.parentNode?.childNodes.forEach(element => {
+        let el = element as HTMLElement;
+        if (el.classList.contains('active')) {
+          el.classList.remove('active');
+        }
+      });
+      event.currentTarget.classList.add('active');
       event.preventDefault();
       event.stopPropagation();
       heading.onClick();

--- a/src/toc_tree.tsx
+++ b/src/toc_tree.tsx
@@ -61,6 +61,41 @@ class TOCTree extends React.Component<IProperties, IState> {
   render() {
     const Toolbar = this.props.toolbar;
 
+    /* keyPress function to handle selection */
+    const keyPressed = (event: React.KeyboardEvent) => {
+      switch (event.key) {
+        case 'ArrowDown':
+          arrowDown();
+          break;
+        case 'ArrowUp':
+          arrowUp();
+          break;
+        default:
+      }
+    };
+
+    const arrowDown = () => {
+      let ul = document.getElementsByClassName('jp-TableOfContents-content')[0];
+      let activeElment = ul.getElementsByClassName('active')[0];
+      let next = activeElment?.nextElementSibling as HTMLElement;
+      if (next) {
+        activeElment.classList.remove('active');
+        next.classList.add('active');
+        next.click();
+      }
+    };
+
+    const arrowUp = () => {
+      let ul = document.getElementsByClassName('jp-TableOfContents-content')[0];
+      let activeElment = ul.getElementsByClassName('active')[0];
+      let prev = activeElment?.previousElementSibling as HTMLElement;
+      if (prev) {
+        activeElment.classList.remove('active');
+        prev.classList.add('active');
+        prev.click();
+      }
+    };
+
     // Map the heading objects onto a list of JSX elements...
     let i = 0;
     let list: JSX.Element[] = this.props.toc.map(el => {
@@ -73,10 +108,12 @@ class TOCTree extends React.Component<IProperties, IState> {
       );
     });
     return (
-      <div className="jp-TableOfContents">
+      <div className="jp-TableOfContents" onKeyDown={keyPressed} tabIndex={0}>
         <header>{this.props.title}</header>
         {Toolbar && <Toolbar />}
-        <ul className="jp-TableOfContents-content">{list}</ul>
+        <ul className="jp-TableOfContents-content" tabIndex={0}>
+          {list}
+        </ul>
       </div>
     );
   }

--- a/style/index.css
+++ b/style/index.css
@@ -29,7 +29,8 @@
   padding-bottom: 8px;
 }
 
-.jp-TableOfContents-content li:hover {
+.jp-TableOfContents-content li:hover,
+.jp-TableOfContents-content li.active {
   background: var(--jp-layout-color2);
 }
 


### PR DESCRIPTION
## Reference:
#99 

## Code Changes
KeyDown event added to TOC content and list navigation and selection of content on notebook.
Highlight the active list element on selection and keyboard navigation

![toc](https://user-images.githubusercontent.com/4777119/82666379-722d2000-9c53-11ea-9c00-1ae96ecef84f.gif)


