### PR TITLE
Add collapsible notebooks config to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ jupyter labextension install @jupyterlab/toc
 ## Settings
 
 Once installed, extension behavior can be modified via the following settings which can be set in JupyterLab's advanced settings editor:
+
 - **collapsibleNotebooks**: enable the ability to collapse sections of notebooks from the ToC
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Here is an animation showing the extension's use, with a notebook from the [Pyth
 jupyter labextension install @jupyterlab/toc
 ```
 
+### Collapsing Notebooks
+To enable the ability to collapse sections of notebooks from the ToC, open the settings editor (shortcut is ⌘,), navigate to the "Table of Contents" settings, and set `collapsibleNotebooks` to `true`:
+![image](https://user-images.githubusercontent.com/6673460/85434150-3c79a080-b54b-11ea-8f22-7c1cd9ad177e.png)
+
+
 ## Development
 
 For a development install, do the following in the repository directory:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Here is an animation showing the extension's use, with a notebook from the [Pyth
 jupyter labextension install @jupyterlab/toc
 ```
 
-## Configuration
-### Enable Collapsing Notebooks
-To enable the ability to collapse sections of notebooks from the ToC, open the settings editor (shortcut is ⌘,), navigate to the "Table of Contents" settings, and set `collapsibleNotebooks` to `true`:
-![image](https://user-images.githubusercontent.com/6673460/85434150-3c79a080-b54b-11ea-8f22-7c1cd9ad177e.png)
+## Settings
+
+Once installed, extension behavior can be modified via the following settings which can be set in JupyterLab's advanced settings editor:
+- **collapsibleNotebooks**: enable the ability to collapse sections of notebooks from the ToC
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Here is an animation showing the extension's use, with a notebook from the [Pyth
 jupyter labextension install @jupyterlab/toc
 ```
 
-### Collapsing Notebooks
+## Configuration
+### Enable Collapsing Notebooks
 To enable the ability to collapse sections of notebooks from the ToC, open the settings editor (shortcut is ⌘,), navigate to the "Table of Contents" settings, and set `collapsibleNotebooks` to `true`:
 ![image](https://user-images.githubusercontent.com/6673460/85434150-3c79a080-b54b-11ea-8f22-7c1cd9ad177e.png)
-
 
 ## Development
 


### PR DESCRIPTION
Due to the changes from #132 in response to #123, the README needs to document how users can change the settings to enable the collapsing notebooks behavior in the ToC.