### PR TITLE
Add ToC indentation support

### DIFF
--- a/src/generators/notebook/render.tsx
+++ b/src/generators/notebook/render.tsx
@@ -58,14 +58,18 @@ function render(
 
           // Render the heading item:
           jsx = (
-            <div className="toc-entry-holder">
+            <div className={'toc-entry-holder toc-entry-level-' + item.level}>
               {button}
               {jsx}
             </div>
           );
         } else {
           // Render the heading item without the dropdown button:
-          jsx = <div className="toc-entry-holder">{jsx}</div>;
+          jsx = (
+            <div className={'toc-entry-holder toc-entry-level-' + item.level}>
+              {jsx}
+            </div>
+          );
         }
       }
       return jsx;
@@ -86,14 +90,18 @@ function render(
           let button = twistButton(item.cellRef, collapsed || false, onClick);
           setCollapsedState(tracker, item.cellRef, collapsed);
           jsx = (
-            <div className="toc-entry-holder">
+            <div className={'toc-entry-holder toc-entry-level-' + item.level}>
               {button}
               {jsx}
             </div>
           );
         } else {
           // Render the heading item without the dropdown button:
-          jsx = <div className="toc-entry-holder">{jsx}</div>;
+          jsx = (
+            <div className={'toc-entry-holder toc-entry-level-' + item.level}>
+              {jsx}
+            </div>
+          );
         }
       }
       return jsx;

--- a/style/index.css
+++ b/style/index.css
@@ -382,6 +382,30 @@
   padding-left: 24px;
 }
 
+.toc-entry-level-1 {
+  padding-left: 0;
+}
+
+.toc-entry-level-2 {
+  padding-left: 1em;
+}
+
+.toc-entry-level-3 {
+  padding-left: 2em;
+}
+
+.toc-entry-level-4 {
+  padding-left: 3em;
+}
+
+.toc-entry-level-5 {
+  padding-left: 4em;
+}
+
+.toc-entry-level-6 {
+  padding-left: 5em;
+}
+
 /* styles for tags */
 
 .toc-tag-label {

--- a/style/index.css
+++ b/style/index.css
@@ -378,7 +378,7 @@
   font-size: inherit;
 }
 
-.toc-cell-item {
+.toc-collapse-button + .toc-cell-item {
   padding-left: 24px;
 }
 


### PR DESCRIPTION
This PR resolves #114 by

-   adding indentation to ToC entries

## Notes

-   This PR does not currently indent either code or Markdown entries for reasons of preserving full width rendering. If we indent code or Markdown, this could make the content illegible for small widths.

## Screenshots

### Collapsing enabled

<img width="932" alt="Screen Shot 2020-07-27 at 12 51 36 AM" src="https://user-images.githubusercontent.com/2643044/88517893-6be55800-cfa4-11ea-8969-bef511174446.png">

### Collapsing enabled + numbering enabled

<img width="932" alt="Screen Shot 2020-07-27 at 12 51 51 AM" src="https://user-images.githubusercontent.com/2643044/88517902-6e47b200-cfa4-11ea-924f-c118baa2a94c.png">

### Collapsing enabled + numbering enabled + code + Markdown

<img width="932" alt="Screen Shot 2020-07-27 at 12 58 31 AM" src="https://user-images.githubusercontent.com/2643044/88517912-70117580-cfa4-11ea-9cc9-41ce24fa3746.png">

### Collapsing disabled

<img width="932" alt="Screen Shot 2020-07-27 at 1 02 28 AM" src="https://user-images.githubusercontent.com/2643044/88518197-eada9080-cfa4-11ea-9c94-fe8efbc767ef.png">

### Collapasing disabled + numbering enabled

<img width="932" alt="Screen Shot 2020-07-27 at 12 56 53 AM" src="https://user-images.githubusercontent.com/2643044/88517904-6ee04880-cfa4-11ea-86b6-64a6b63ae0de.png">

### Collapsing disabled + numbering enabled + code + Markdown

<img width="932" alt="Screen Shot 2020-07-27 at 12 57 26 AM" src="https://user-images.githubusercontent.com/2643044/88517910-6f78df00-cfa4-11ea-8edf-87c241f96292.png">
